### PR TITLE
feat: Add fallback value for negative turbidity sensor readings (40-50 NTU range)

### DIFF
--- a/app/Http/Controllers/SensorController.php
+++ b/app/Http/Controllers/SensorController.php
@@ -23,6 +23,11 @@ class SensorController extends Controller
             $validatedData['suhu'] = mt_rand(2800, 3000) / 100;
         }
 
+        // Normalize invalid kekeruhan (negative values) to a random value within 40.00 - 50.00 NTU
+        if (isset($validatedData['kekeruhan']) && (float)$validatedData['kekeruhan'] < 0) {
+            $validatedData['kekeruhan'] = mt_rand(4000, 5000) / 100;
+        }
+
         try {
             $sensorData = Sensor::create($validatedData);
 


### PR DESCRIPTION
## Description
This pull request implements a fallback mechanism for negative turbidity (kekeruhan) values in the sensor data storage system. When the sensor sends negative turbidity readings, the system now automatically replaces them with random values between 40-50 NTU, ensuring data consistency and preventing invalid negative turbidity measurements from being stored in the database.

## Key Changes
- **Modified `app/Http/Controllers/SensorController.php`**: Added fallback logic for negative turbidity values in the `store` method (lines 26-29)
- **Enhanced data validation**: Implemented automatic normalization of invalid turbidity readings similar to existing temperature fallback logic
- **Maintained existing functionality**: All other sensor data processing remains unchanged

## Specific File Changes and Impact

### `app/Http/Controllers/SensorController.php`
**Location**: Lines 26-29 (new code block)

**Before**:
```php
// Normalize invalid suhu (-127) to a random value within 28.00 - 30.00
if (isset($validatedData['suhu']) && (float)$validatedData['suhu'] === -127.0) {
    $validatedData['suhu'] = mt_rand(2800, 3000) / 100;
}

try {
    $sensorData = Sensor::create($validatedData);
```

**After**:
```php
// Normalize invalid suhu (-127) to a random value within 28.00 - 30.00
if (isset($validatedData['suhu']) && (float)$validatedData['suhu'] === -127.0) {
    $validatedData['suhu'] = mt_rand(2800, 3000) / 100;
}

// Normalize invalid kekeruhan (negative values) to a random value within 40.00 - 50.00 NTU
if (isset($validatedData['kekeruhan']) && (float)$validatedData['kekeruhan'] < 0) {
    $validatedData['kekeruhan'] = mt_rand(4000, 5000) / 100;
}

try {
    $sensorData = Sensor::create($validatedData);
```

**Impact**:
- Prevents negative turbidity values from being stored in the database
- Ensures data consistency for downstream processing and analytics
- Maintains realistic turbidity readings within acceptable water quality measurement ranges
- Follows the same pattern as existing temperature fallback logic for consistency

## Rationale for Changes
Negative turbidity readings are physically impossible and indicate sensor malfunction or measurement errors. By implementing this fallback mechanism, we ensure that:
1. **Data Integrity**: Database maintains only valid, realistic turbidity measurements
2. **System Reliability**: Prevents downstream applications from processing invalid negative values
3. **Consistency**: Follows established pattern of data normalization already implemented for temperature sensors
4. **Water Quality Standards**: 40-50 NTU range represents moderately turbid water, which is more realistic than negative values

## Type of Changes
- [x] New Feature: Adds a new feature to the project
- [ ] Documentation: Adds or updates documentation
- [ ] Bug fix: Fixes a bug
- [ ] Refactoring: Code improvement without changing functionality

## Manual Testing Steps

### Test Case 1: Normal Positive Turbidity Value
1. Send POST request to `/api/sensor/store` endpoint with valid data:
   ```json
   {
     "kekeruhan": 25.5,
     "keasaman": 7.2,
     "suhu": 28.5
   }
   ```
2. **Expected Result**: Data should be stored as-is without modification
3. **Verification**: Check database record shows `kekeruhan: 25.5`

### Test Case 2: Negative Turbidity Value (Fallback Trigger)
1. Send POST request to `/api/sensor/store` endpoint with negative turbidity:
   ```json
   {
     "kekeruhan": -10.5,
     "keasaman": 7.2,
     "suhu": 28.5
   }
   ```
2. **Expected Result**: Negative value should be replaced with random value between 40.00-50.00
3. **Verification**: Check database record shows `kekeruhan` value between 40.00 and 50.00

### Test Case 3: Zero Turbidity Value
1. Send POST request with zero turbidity:
   ```json
   {
     "kekeruhan": 0,
     "keasaman": 7.2,
     "suhu": 28.5
   }
   ```
2. **Expected Result**: Zero value should be stored as-is (not negative, so no fallback)
3. **Verification**: Check database record shows `kekeruhan: 0`

### Test Case 4: Combined Fallback (Both Temperature and Turbidity)
1. Send POST request with both invalid temperature and negative turbidity:
   ```json
   {
     "kekeruhan": -5.0,
     "keasaman": 7.2,
     "suhu": -127
   }
   ```
2. **Expected Result**: Both values should be normalized (temperature: 28.00-30.00, turbidity: 40.00-50.00)
3. **Verification**: Check database shows both values within their respective fallback ranges

### Test Case 5: API Response Verification
1. Perform any of the above test cases
2. **Expected Result**: API should return 201 status with success message and transformed data
3. **Verification**: Response body should show the fallback values, not the original negative values

## Known Issues and Future Improvements

### Potential Enhancements
- **Configurable Fallback Ranges**: Currently hardcoded to 40-50 NTU range. Future versions could make this configurable through environment variables or database settings
- **Logging Enhancement**: Add logging when fallback values are applied to track sensor malfunction patterns
- **Statistical Analysis**: Implement monitoring to track frequency of negative readings and identify problematic sensors
- **Alternative Fallback Strategies**: Consider using historical averages or nearby sensor readings instead of random values

### Technical Debt Considerations
- **Code Duplication**: The fallback pattern is repeated for temperature and turbidity. Future refactoring could extract this into a reusable method
- **Magic Numbers**: The range values (4000, 5000) could be extracted to named constants for better maintainability
- **Validation Consistency**: Consider if other sensor parameters (keasaman) need similar fallback mechanisms