### PR TITLE
Refactor FeedController to use FeedSchedulingService for manual and scheduled feeding operations

### DIFF
--- a/app/Http/Controllers/FeedController.php
+++ b/app/Http/Controllers/FeedController.php
@@ -8,49 +8,44 @@ use App\Models\FeedSchedule;
 use App\Models\FeedExecution;
 use App\Http\Resources\FeedResource;
 use App\Http\Resources\FeedExecutionResource;
+use App\Services\FeedSchedulingService;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Carbon;
-use PhpMqtt\Client\ConnectionSettings;
-use PhpMqtt\Client\MqttClient;
 
 class FeedController extends Controller
 {
+    protected FeedSchedulingService $feedSchedulingService;
+
+    public function __construct(FeedSchedulingService $feedSchedulingService)
+    {
+        $this->feedSchedulingService = $feedSchedulingService;
+    }
+
+    /**
+     * Beri pakan manual (tidak terkait jadwal)
+     */
     public function beriPakan(Request $request)
     {
-        // --- Konfigurasi MQTT (Sudah Diupdate) ---
-        $server   = 'chameleon.lmq.cloudamqp.com';
-        $port     = 8883;
-        $clientId = 'laravel-client-' . rand();
-        $username = 'anfvrqjy:anfvrqjy';
-        $password = 'V4OJdwnNv8d8nN2OmCbLrdBqDF5-WS5G';
+        // Gunakan service untuk execute manual feed
+        $result = $this->feedSchedulingService->executeManualFeed();
 
-        // GANTI topik dinamis menjadi topik statis/broadcast
-        $topic    = 'cota/command/feed_all';
-
-        try {
-            // Pengaturan koneksi untuk menggunakan TLS (koneksi aman)
-            $connectionSettings = (new ConnectionSettings)
-                ->setUseTls(true)
-                ->setTlsSelfSignedAllowed(true)
-                ->setUsername($username)
-                ->setPassword($password);
-
-            $mqtt = new MqttClient($server, $port, $clientId);
-            $mqtt->connect($connectionSettings, true);
-            $mqtt->publish($topic, 'FEED', MqttClient::QOS_AT_LEAST_ONCE);
-            $mqtt->disconnect();
-
-            // Simpan record ke FeedExecution untuk tracking
-            FeedExecution::create([
-                'status' => 'pending',
-                'executed_at' => now(),
+        if ($result['success']) {
+            return response()->json([
+                'status' => 'success',
+                'message' => $result['message'],
+                'data' => $result['execution']
             ]);
-
-            return response()->json(['status' => 'success', 'message' => 'Perintah pakan broadcast telah dikirim!']);
-        } catch (\Exception $e) {
-            return response()->json(['status' => 'error', 'message' => 'Gagal terhubung ke MQTT Broker: ' . $e->getMessage()], 500);
         }
+
+        return response()->json([
+            'status' => 'error',
+            'message' => $result['message']
+        ], 500);
     }
+
+    /**
+     * Beri pakan terjadwal (trigger manual dari frontend untuk jadwal tertentu)
+     */
     public function beriPakanTerjadwal(Request $request, $id)
     {
         $jadwal = FeedSchedule::find($id);
@@ -62,69 +57,30 @@ class FeedController extends Controller
             ], 404);
         }
 
-        $today = Carbon::today()->toDateString(); // gunakan Carbon
+        // Gunakan service untuk execute feed dengan schedule_id
+        $result = $this->feedSchedulingService->executeFeed($jadwal);
 
-        // Cek apakah sudah dieksekusi hari ini
-        if ($jadwal->last_executed_at === $today) {
+        if ($result['success']) {
             return response()->json([
-                'message' => 'Jadwal ini sudah dieksekusi hari ini.',
-                'status'  => 'info'
+                'message' => $result['message'],
+                'status'  => 'success',
+                'data' => $result['execution'] ?? null
             ], 200);
         }
 
-        try {
-            $client = new \GuzzleHttp\Client();
-            $response = $client->get("http://192.168.18.89/beri-pakan");
-
-            if ($response->getStatusCode() === 200) {
-                // Update jadwal terakhir dieksekusi
-                $jadwal->update([
-                    'last_executed_at' => $today,
-                ]);
-
-                feedExecution::create([
-                    'status' => 'success',
-                    'executed_at' => now(),
-                ]);
-
-                return response()->json([
-                    'message' => 'Pakan berhasil diberikan!',
-                    'status'  => 'success'
-                ], 200);
-            }
-
-            return response()->json([
-                'message' => 'Gagal menembak API! (Status: ' . $response->getStatusCode() . ')',
-                'status'  => 'error'
-            ], $response->getStatusCode());
-        } catch (\Exception $e) {
-            FeedExecution::create([
-                'status' => 'failed',
-                'executed_at' => now(),
-            ]);
-
-            return response()->json([
-                'message' => 'Error: ' . $e->getMessage(),
-                'status'  => 'error'
-            ], 500);
-        }
+        return response()->json([
+            'message' => $result['message'],
+            'status'  => 'error'
+        ], 500);
     }
 
+    /**
+     * Get schedules yang siap dieksekusi (dalam 1 menit terakhir)
+     */
     public function siap()
     {
-        $now = Carbon::now();
-        $satuMenitLalu = $now->copy()->subMinute();
-        $tanggalHariIni = $now->toDateString();
-
-        $jadwals = FeedSchedule::whereTime('waktu_pakan', '<=', $now->format('H:i:s'))
-            ->whereTime('waktu_pakan', '>=', $satuMenitLalu->format('H:i:s'))
-            ->where(function ($q) use ($tanggalHariIni) {
-                $q->whereNull('last_executed_at')
-                    ->orWhereDate('last_executed_at', '<>', $tanggalHariIni);
-            })
-            ->get();
-
-        return response()->json($jadwals);
+        $readySchedules = $this->feedSchedulingService->getReadySchedules();
+        return response()->json($readySchedules);
     }
 
     public function status(Request $request)


### PR DESCRIPTION
- Removed direct MQTT connection logic and replaced it with service calls for executing manual and scheduled feeds.
- Enhanced error handling and response structure for feeding operations.
- Simplified the retrieval of ready schedules by utilizing the service layer.